### PR TITLE
docs: fix links broken after migration from HTTPure to HTTPurple

### DIFF
--- a/docs/Responses.md
+++ b/docs/Responses.md
@@ -20,7 +20,7 @@ corresponding to each helper--for instance, `HTTPure.ok'` and
 they also return response headers--see the [Setting Response
 Headers](#setting-response-headers) section below for more details.
 
-For a full list of helpers, see the [Response](../src/HTTPure/Response.purs)
+For a full list of helpers, see the [Response](../src/HTTPurple/Response.purs)
 module.
 
 In some cases, the defined helpers don't cover your needs--for instance, if

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -303,7 +303,7 @@ router { method } = HTTPurple.ok $ "received a " <> show method
 ```
 
 To see the list of methods that HTTPure understands, see the
-[Method](../src/HTTPure/Method.purs) module. To see an example server that
+[Method](../src/HTTPurple/Method.purs) module. To see an example server that
 routes based on the HTTP method, see [the Post
 example](./Examples/Post/Main.purs).
 


### PR DESCRIPTION
As result of migration directory `src/HTTPure` was renamed to `src/HTTPurple`, but some references weren't updated. Fix that.