### PR TITLE
Implemented QUERY in accordancy with the RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unpublished
+- Add support for the HTTP `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008))
 
 ## v4.0.0
 - Update to latest version of node libraries (#15 by @JordanMartinez)

--- a/docs/Examples/Query/Readme.md
+++ b/docs/Examples/Query/Readme.md
@@ -1,0 +1,19 @@
+# Query Example
+
+This is a basic example of handling the HTTP `QUERY` method
+([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)). It responds to a
+`QUERY` on any path with the query content echoed back in the response body,
+and to a `GET` on the same path with an explanatory message, to illustrate
+that both share a route but are distinguished by method.
+
+To run the example server, run:
+
+```bash
+nix-shell --run 'example Query'
+```
+
+Or, without nix:
+
+```bash
+spago -x test.dhall run --main Examples.Query.Main
+```

--- a/docs/Examples/Query/Readme.md
+++ b/docs/Examples/Query/Readme.md
@@ -15,5 +15,5 @@ nix-shell --run 'example Query'
 Or, without nix:
 
 ```bash
-spago -x test.dhall run --main Examples.Query.Main
+spago run --main Examples.Query.Main
 ```

--- a/src/HTTPurple/Method.purs
+++ b/src/HTTPurple/Method.purs
@@ -19,6 +19,7 @@ data Method
   | Options
   | Trace
   | Patch
+  | Query
 
 -- | If two `Methods` are the same constructor, they are equal.
 derive instance eqMethod :: Eq Method
@@ -34,6 +35,7 @@ instance showMethod :: Show Method where
   show Options = "Options"
   show Trace = "Trace"
   show Patch = "Patch"
+  show Query = "Query"
 
 -- | Take an HTTP `Request` and extract the `Method` for that request.
 read :: IncomingMessage IMServer -> Method
@@ -46,4 +48,5 @@ read = method >>> case _ of
   "OPTIONS" -> Options
   "TRACE" -> Trace
   "PATCH" -> Patch
+  "QUERY" -> Query
   _ -> Get

--- a/test/Examples/Query/Main.purs
+++ b/test/Examples/Query/Main.purs
@@ -1,0 +1,40 @@
+module Examples.Query.Main where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Effect.Aff (Aff)
+import Effect.Console (log)
+import HTTPurple (Method(..), Request, Response, ServerM, notFound, ok, serve, toString)
+import Routing.Duplex (RouteDuplex')
+import Routing.Duplex as RD
+import Routing.Duplex.Generic as G
+
+data Route = Test
+
+derive instance Generic Route _
+
+route :: RouteDuplex' Route
+route = RD.root $ G.sum
+  { "Test": G.noArgs
+  }
+
+-- | Route to the correct handler
+router :: Request Route -> Aff Response
+router { body, method: Query } = toString body >>= ok
+router { method: Get } = ok "send a QUERY request with a body to see it echoed back"
+router _ = notFound
+
+-- | Boot up the server
+main :: ServerM
+main =
+  serve { hostname: "localhost", port: 8080, onStarted } { route, router }
+  where
+  onStarted = do
+    log " ┌───────────────────────────────────────────────┐"
+    log " │ Server now up on port 8080                    │"
+    log " │                                               │"
+    log " │ To test, run:                                 │"
+    log " │  > curl -XQUERY --data 'q=foo' localhost:8080 │"
+    log " │    # => q=foo                                 │"
+    log " └───────────────────────────────────────────────┘"

--- a/test/Test/HTTPurple/BodySpec.purs
+++ b/test/Test/HTTPurple/BodySpec.purs
@@ -30,7 +30,7 @@ readSpec :: Test
 readSpec =
   describe "read" do
     it "is the body of the Request" do
-      body <- (liftEffect <<< read) =<< mockRequest "" "GET" "" "test" []
+      body <- (liftEffect <<< read) =<< mockRequest "" "QUERY" "" "test" []
       string <- liftEffect $ fromMaybe "" <$> readString (toStream body) UTF8
       string ?= "test"
 

--- a/test/Test/HTTPurple/IntegrationSpec.purs
+++ b/test/Test/HTTPurple/IntegrationSpec.purs
@@ -17,13 +17,14 @@ import Examples.MultiRoute.Main as MultiRoute
 import Examples.NodeMiddleware.Main as NodeMiddleware
 import Examples.PathSegments.Main as PathSegments
 import Examples.Post.Main as Post
+import Examples.Query.Main as Query
 import Examples.QueryParameters.Main as QueryParameters
 import Examples.SSL.Main as SSL
 import Foreign.Object (empty, singleton)
 import Foreign.Object as Object
 import Node.Buffer (toArray)
 import Node.FS.Aff (readFile)
-import Test.HTTPurple.TestHelpers (Test, awaitStarted, awaitStartedSecure, get, get', getBinary, getHeader, post, postBinary, (?=))
+import Test.HTTPurple.TestHelpers (Test, awaitStarted, awaitStartedSecure, get, get', getBinary, getHeader, post, postBinary, query, query', (?=))
 import Test.Spec (describe, it)
 import Test.Spec.Assertions.String (shouldStartWith)
 
@@ -33,6 +34,45 @@ asyncResponseSpec =
     close <- liftEffect AsyncResponse.main
     awaitStarted 8080
     response <- get 8080 empty "/"
+    liftEffect $ close $ pure unit
+    response ?= "hello world!"
+
+queryWithRequestBodySpec :: Test
+queryWithRequestBodySpec =
+  it "runs a QUERY and accepts a request body" do
+    close <- liftEffect Query.main
+    awaitStarted 8080
+    let body = "{ \"lastName\": { \"eq\": \"waltz\", \"caseSensitive\": false } } "
+    response <- query 8080 empty "/" body
+    liftEffect $ close $ pure unit
+    response ?= body
+
+queryWithEmptyBodySpec :: Test
+queryWithEmptyBodySpec =
+  it "runs a QUERY with an empty request body" do
+    close <- liftEffect Query.main
+    awaitStarted 8080
+    response <- query 8080 empty "/" ""
+    liftEffect $ close $ pure unit
+    response ?= ""
+
+queryVsGetSpec :: Test
+queryVsGetSpec =
+  it "distinguishes a QUERY from a GET on the same route" do
+    close <- liftEffect Query.main
+    awaitStarted 8080
+    getResponse <- get 8080 empty "/"
+    queryResponse <- query 8080 empty "/" "q=foo"
+    liftEffect $ close $ pure unit
+    getResponse ?= "send a QUERY request with a body to see it echoed back"
+    queryResponse ?= "q=foo"
+
+querySslSpec :: Test
+querySslSpec =
+  it "runs a QUERY over HTTPS" do
+    close <- liftEffect SSL.main
+    awaitStartedSecure 8080
+    response <- query' 8080 empty "/" "q=foo"
     liftEffect $ close $ pure unit
     response ?= "hello world!"
 
@@ -205,6 +245,10 @@ integrationSpec :: Test
 integrationSpec =
   describe "Integration" do
     asyncResponseSpec
+    queryWithRequestBodySpec
+    queryWithEmptyBodySpec
+    queryVsGetSpec
+    querySslSpec
     binaryRequestSpec
     binaryResponseSpec
     chunkedSpec

--- a/test/Test/HTTPurple/MethodSpec.purs
+++ b/test/Test/HTTPurple/MethodSpec.purs
@@ -2,10 +2,7 @@ module Test.HTTPurple.MethodSpec where
 
 import Prelude
 
-import HTTPurple.Method
-  ( Method(Get, Post, Put, Delete, Head, Connect, Options, Trace, Patch)
-  , read
-  )
+import HTTPurple.Method (Method(Get, Post, Put, Delete, Head, Connect, Options, Trace, Patch, Query), read)
 import Test.HTTPurple.TestHelpers (Test, mockRequest, (?=))
 import Test.Spec (describe, it)
 
@@ -39,6 +36,9 @@ showSpec =
     describe "with a Patch" do
       it "is 'Patch'" do
         show Patch ?= "Patch"
+    describe "with a Query" do
+      it "is 'Query'" do
+        show Query ?= "Query"
 
 readSpec :: Test
 readSpec =
@@ -46,6 +46,14 @@ readSpec =
     describe "with a 'GET' Request" do
       it "is Get" do
         request <- mockRequest "" "GET" "" "" []
+        read request ?= Get
+    describe "with a 'QUERY' Request" do
+      it "is Query" do
+        request <- mockRequest "" "QUERY" "" "" []
+        read request ?= Query
+    describe "with a lowercase 'query' Request" do
+      it "is Get, since HTTP method tokens are case-sensitive" do
+        request <- mockRequest "" "query" "" "" []
         read request ?= Get
 
 methodSpec :: Test

--- a/test/Test/HTTPurple/TestHelpers.purs
+++ b/test/Test/HTTPurple/TestHelpers.purs
@@ -221,6 +221,37 @@ get' ::
   Aff String
 get' port headers path = request' true port "GET" headers path >>= toString
 
+queryReq ::
+  Boolean ->
+  Int ->
+  Object String ->
+  String ->
+  String ->
+  Aff String
+queryReq secure port headers path = requestString secure port "QUERY" headers path >=> toString
+
+-- | Run an HTTP QUERY with the given url and return an Aff that contains the
+-- | string with the response body. You may think of QUERY as being GET, but allowing
+-- | a request body to be sent. In this case, we make the request body a string.
+query ::
+  Int ->
+  Object String ->
+  String ->
+  String ->
+  Aff String
+query = queryReq false
+
+-- | Run an HTTPS QUERY with the given url and return an Aff that contains the
+-- | string with the response body. You may think of QUERY as being GET, but allowing
+-- | a request body to be sent. In this case, we make the request body a string.
+query' ::
+  Int ->
+  Object String ->
+  String ->
+  String ->
+  Aff String
+query' = queryReq true
+
 -- | Run an HTTP POST with the given url and body and return an Aff that
 -- | contains the string with the response body.
 post ::


### PR DESCRIPTION
Hey! So, I wasn't able to open an issue as it looks like I don't have the ability to open an issue on this repository. However, there is a [recent RFC](https://www.rfc-editor.org/info/rfc10008/) which includes `QUERY` support.

You may think of this as basically being GET, but where you can pass a request body. A lot of people have resorted to using POSTs to solve the problem that this RFC finally solves.

All tests pass.